### PR TITLE
Fix import issue causing app crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@types/react-dom": "^18.2.6",
     "@vitejs/plugin-react": "^4.0.3",
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.25",
-    "vite": "^4.4.4"
-    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.31",
+    "vite": "^5.0.5",
+    "tailwindcss": "^3.3.3"
   }
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import {Tilt} from "react-tilt";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import {Tilt} from "react-tilt";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";


### PR DESCRIPTION
Fix import and package.json issues, update vite and postcss

- Corrected the import statement for 'react-tilt' by changing from default to named import to prevent app crashes.
- Resolved issues in package.json that were causing conflicts.
- Updated 'vite' and 'postcss' to their latest versions for improved performance and compatibility.