### PR TITLE
fix: reCAPTCHA attribution and site-key guard

### DIFF
--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -237,6 +237,9 @@ const ContactForm = () => {
       >
         {loading ? "Sending..." : "Send"}
       </button>
+      <p className="mt-3 text-xs text-secondary/70">
+        This site is protected by reCAPTCHA.
+      </p>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- Add a minimal muted notice under the contact form submit button: "This site is protected by reCAPTCHA."
- Compensates for the hidden reCAPTCHA badge per Google’s attribution guidance.

## Test plan
- [ ] Contact form still submits as before
- [ ] Attribution appears under the submit button
- [ ] Attribution stays low-contrast and does not disrupt layout

Made with [Cursor](https://cursor.com)