### PR TITLE
Add vscode settings.json for workspace TypeScript and Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ dist-ssr
 .env
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true
+}


### PR DESCRIPTION
## Summary
- Add `.vscode/settings.json` with workspace TypeScript SDK settings and Tailwind CSS file association.
- Un-ignore `.vscode/settings.json` when it was gitignored so workspace editor settings are shared.

Related: https://linear.app/sanidhyy/issue/SAN-121/migrate-vscode-settingsjson

## Test plan
- [ ] Open the repo in the editor and confirm workspace TypeScript is offered (TypeScript repos)
- [ ] For Tailwind repos, confirm `*.css` is associated with Tailwind CSS